### PR TITLE
Lsコマンドを作ろうの課題提出

### DIFF
--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,0 +1,33 @@
+#!/usr/bin/env ruby
+
+children = Dir.glob('*').sort
+
+# 文字数の最大値を算出。
+string_length_max = children.map { |items| items.length }.max
+
+MAX_COLUMN = 3
+
+output_row_num = children.size % 3 > 0 ? children.size / 3 + 1 : children.size / 3
+
+results = []
+children.each_slice(output_row_num) do |items|
+  results << items.map { |item| item }
+end
+
+tmp_arry = []
+i = 0
+output_row_num.times do
+  results.each do |item|
+    tmp_arry << item[i]
+  end
+  i += 1
+end
+
+sorted_results = []
+sorted_results.each_slice(MAX_COLUMN) do |items|
+  sorted_results << items.map { |item| item }
+end
+
+sorted_results.each do |items|
+  puts items.map { |item| "% -#{string_length_max}s " % item }.join
+end

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,33 +1,66 @@
 #!/usr/bin/env ruby
+# frozen_string_literal: true
 
-children = Dir.glob('*').sort
+class ListSegments
+  MAX_COLUMN = 3
 
-# 文字数の最大値を算出。
-string_length_max = children.map { |items| items.length }.max
+  def main
+    children = Dir.glob('*').sort
 
-MAX_COLUMN = 3
+    child_max_length = children.map(&:length).max
 
-output_row_num = children.size % 3 > 0 ? children.size / 3 + 1 : children.size / 3
+    output_row = (children.size % 3).positive? ? children.size / 3 + 1 : children.size / 3
 
-results = []
-children.each_slice(output_row_num) do |items|
-  results << items.map { |item| item }
-end
+    sliced_by_row = slice_children_each_row(children, output_row)
 
-tmp_arry = []
-i = 0
-output_row_num.times do
-  results.each do |item|
-    tmp_arry << item[i]
+    sorted_arry = sorted_arry_factory(output_row, sliced_by_row)
+
+    results = output_arry_factory(sorted_arry)
+
+    results.each do |items|
+      puts items.map { |item|
+        format("% -#{child_max_length}s ", item) unless item.nil?
+      }.join
+    end
   end
-  i += 1
+
+  private
+
+  # @param [Object] row
+  # @param [Object] children
+  # @return [Array]
+  def slice_children_each_row(children, row)
+    sliced_by_row = []
+    children.each_slice(row) do |items|
+      sliced_by_row << items.map { |item| item }
+    end
+    sliced_by_row
+  end
+
+  # @param [Object] row
+  # @param [Object] sliced_by_row
+  # @return [Array]
+  def sorted_arry_factory(row, sliced_by_row)
+    tmp_arry = []
+    i = 0
+    row.times do
+      sliced_by_row.each do |item|
+        tmp_arry << item[i]
+      end
+      i += 1
+    end
+    tmp_arry
+  end
+
+  # @param [Object] arry
+  # @return [Array]
+  def output_arry_factory(arry)
+    results = []
+    arry.each_slice(MAX_COLUMN) do |items|
+      results << items.map { |item| item }
+    end
+    results
+  end
 end
 
-sorted_results = []
-sorted_results.each_slice(MAX_COLUMN) do |items|
-  sorted_results << items.map { |item| item }
-end
-
-sorted_results.each do |items|
-  puts items.map { |item| "% -#{string_length_max}s " % item }.join
-end
+ListSegments.new.main

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -9,7 +9,7 @@ class ListSegments
 
     child_max_length = children.map(&:length).max
 
-    output_row = (children.size % 3).positive? ? children.size / 3 + 1 : children.size / 3
+    output_row = children.size.ceil / 3
 
     sliced_by_row = slice_children_each_row(children, output_row)
 
@@ -42,8 +42,7 @@ class ListSegments
   # @return [Array]
   def sorted_arry_factory(row, sliced_by_row)
     tmp_arry = []
-    i = 0
-    row.times do
+    row.times do |i|
       sliced_by_row.each do |item|
         tmp_arry << item[i]
       end
@@ -55,11 +54,7 @@ class ListSegments
   # @param [Object] arry
   # @return [Array]
   def output_arry_factory(arry)
-    results = []
-    arry.each_slice(MAX_COLUMN) do |items|
-      results << items.map { |item| item }
-    end
-    results
+    arry.each_slice(MAX_COLUMN).map { |items| items.map { |item| item } }
   end
 end
 


### PR DESCRIPTION
## 目的
lsコマンドを作ろうの課題のレビューを頂くこと

## 達成条件
レビュワーからマージ許可を頂くこと

## このプルリクでできるようになること
下記の仕様に沿った形で引数を取らないlsコマンドと同様の挙動が再現できる

## 仕様
* gemを使わずにRubyの標準ライブラリのみで実装すること
* 二つ以上のメソッドを自分で定義すること（メソッドの作り方を学ぶため）
* 横に最大3列を維持して表示する
  * ただし、「3列から5列に仕様変更してください」または「3列から100列に変えてください」とあとから言われても必要最小限の変更で対応できるようなロジックにしておくこと

## このプルリクでしないこと
* 引数にファイルやディレクトリを指定可能にする。
* 半角英数字以外のファイル名（ひらがなや漢字など）を持つファイルがあっても表示が崩れない。
* mac拡張属性（@マークで表示される）に対応する。

## レビュー希望箇所
* メソッド・変数の命名について違和感のある箇所があるかどうかご確認頂きたいです
* Rdocの書き方について違和感のある箇所があるかどうかご確認頂きたいです
* コメントがなくても意図が伝わるコードになっているかご確認頂きたいです
## 懸念事項
子階層のファイル・ディレクトリを取得→３要素ずつの２次元配列に詰める→二次元配列をソートして配列に詰める→３要素ずつの２次元配列に詰める→出力する

このような実装フローになっていますが、無駄が多いと感じています。理想は、子階層のファイル・ディレクトリを取得→３要素ずつソートして配列に詰める→出力するとしたかったのですが、出力順に並び替えるソートの方法が思いつきませんでした。この点について実装例などございましたらご教示頂きたいです 🙏🏻 

