### PR TITLE
ls -aオプションの挙動を実装

### DIFF
--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -70,10 +70,8 @@ class ListSegments
   # @return [Array<String>]
   def what_kind_of_option(options)
     flag = 0
-    if options[:a]
-      flag = File::FNM_DOTMATCH
-    end
-    Dir.glob('*', flags: flag, sort:true)
+    flag = File::FNM_DOTMATCH if options[:a]
+    Dir.glob('*', flags: flag, sort: true)
   end
 end
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -69,8 +69,7 @@ class ListSegments
   # @param [Object] options
   # @return [Array<String>]
   def what_kind_of_option(options)
-    flag = 0
-    flag = File::FNM_DOTMATCH if options[:a]
+    flag = options[:a]? File::FNM_DOTMATCH: 0
     Dir.glob('*', flag)
   end
 end

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -71,7 +71,7 @@ class ListSegments
   def what_kind_of_option(options)
     flag = 0
     flag = File::FNM_DOTMATCH if options[:a]
-    Dir.glob('*', flags: flag, sort: true)
+    Dir.glob('*', flag)
   end
 end
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -69,11 +69,11 @@ class ListSegments
   # @param [Object] options
   # @return [Array<String>]
   def what_kind_of_option(options)
+    flag = 0
     if options[:a]
-      Dir.glob('*', File::FNM_DOTMATCH)
-    else
-      Dir.glob('*').sort
+      flag = File::FNM_DOTMATCH
     end
+    Dir.glob('*', flags: flag, sort:true)
   end
 end
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -1,11 +1,20 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
+require 'optparse'
+
 class ListSegments
   MAX_COLUMN = 3
 
   def main
-    children = Dir.glob('*').sort
+    options = {}
+
+    OptionParser.new do |opt|
+      opt.on('-a') { |a| options[:a] = a }
+      opt.parse!(ARGV)
+    end
+
+    children = what_kind_of_option(options)
 
     child_max_length = children.map(&:length).max
 
@@ -55,6 +64,16 @@ class ListSegments
   # @return [Array]
   def output_arry_factory(arry)
     arry.each_slice(MAX_COLUMN).map { |items| items.map { |item| item } }
+  end
+
+  # @param [Object] options
+  # @return [Array<String>]
+  def what_kind_of_option(options)
+    if options[:a]
+      Dir.glob('*', File::FNM_DOTMATCH)
+    else
+      Dir.glob('*').sort
+    end
   end
 end
 

--- a/05.ls/ls.rb
+++ b/05.ls/ls.rb
@@ -69,7 +69,7 @@ class ListSegments
   # @param [Object] options
   # @return [Array<String>]
   def what_kind_of_option(options)
-    flag = options[:a]? File::FNM_DOTMATCH: 0
+    flag = options[:a] ? File::FNM_DOTMATCH : 0
     Dir.glob('*', flag)
   end
 end


### PR DESCRIPTION
## 目的
ls コマンドの-aオプションの挙動を再現すること

## 達成条件
* 仕様に準拠していること
* lsコマンドの-aオプションが再現できていること
* レビュワーのマージ許可を頂くこと

## 仕様
* gemを使わずにRubyの標準ライブラリのみで実装すること
* GitHubでPull Requestとして提出すること
* rubocop-fjordをパスさせること
* 二つ以上のメソッドを自分で定義すること（メソッドの作り方を学ぶため）
* 横に最大3列を維持して表示する
  * ただし、「3列から5列に仕様変更してください」または「3列から100列に変えてください」とあとから言われても必要最小限の変更で対応できるようなロジックにしておくこと

## このプルリクでしないこと
* 引数にファイルやディレクトリを指定可能にする。
* 半角英数字以外のファイル名（ひらがなや漢字など）を持つファイルがあっても表示が崩れない。
* mac拡張属性（@マークで表示される）に対応する。
